### PR TITLE
Add custom "Affiliate" Role

### DIFF
--- a/wpaffiliatemanager/source/Plugin.php
+++ b/wpaffiliatemanager/source/Plugin.php
@@ -194,6 +194,10 @@ class WPAM_Plugin
 		$dbInstaller->doDbInstall();
                 $dbInstaller->doInstallPages( $this->publicPages );
                 $dbInstaller->doFreshInstallDbDefaultData();		
+  
+		// create affiliate role in WP with subscriber capabilities
+		$sub = get_role( 'subscriber' );
+		add_role( 'affiliate', 'Affiliate', $sub->capabilities );
 	}
 
 	private function setMonetaryLocale( $locale ) {

--- a/wpaffiliatemanager/source/Util/UserHandler.php
+++ b/wpaffiliatemanager/source/Util/UserHandler.php
@@ -52,6 +52,7 @@ class WPAM_Util_UserHandler {
 
             $user = new WP_User($userId);
             $user->add_cap(WPAM_PluginConfig::$AffiliateCap);
+            $user->set_role( 'affiliate' );
         }
 
         //Send user email indicating they're approved
@@ -115,6 +116,7 @@ class WPAM_Util_UserHandler {
 
             $user = new WP_User($userId);
             $user->add_cap(WPAM_PluginConfig::$AffiliateCap);
+            $user->set_role( 'affiliate' );
         }
         $affiliate->activate();
         $affiliate->userId = $userId;


### PR DESCRIPTION
Create a new custom "Affiliate" role on activation. Capabilities for the role are duplicated from the WP standard "Subscriber" role.

Then assign new users created via the affiliate registration to the Affiliate role.
