### PR TITLE
Changing jQuery quotes to double quotes, to allow usage of single quote in the translated text

### DIFF
--- a/wpaffiliatemanager/html/admin/affiliate_detail.php
+++ b/wpaffiliatemanager/html/admin/affiliate_detail.php
@@ -156,7 +156,7 @@ $user = $this->viewData['user'];
 				  }
 				} ]
 			);
-			jQuery("#confirmMessage").html('<?php _e( 'Do you want to block all future applications from this email address, or allow them to sign up at a later date?', 'affiliates-manager' ) ?>');
+			jQuery("#confirmMessage").html("<?php _e( 'Do you want to block all future applications from this email address, or allow them to sign up at a later date?', 'affiliates-manager' ) ?>");
 			jQuery("#dialog-confirm").dialog('open');
 
 


### PR DESCRIPTION
Hi,

Following jQuery command `jQuery("xxx").html("yyy")` need to be using double quotes in the `html()` part, or it will break the code as soon as a translation contains a single quote (which is the case for this sentence in French).

Using the French translation with a single quote will break the code, prevent the confirmation pop-up menu to load, and throw the following error in the browser's console : `Uncaught SyntaxError: missing ) after argument list`

Ideally it would be required to change all the single quotes to double quotes for all the jQuery commands in all files, but that require way more work, so for now I'm only fixing the errors that I'm seeing :)

Thanks

Thomas